### PR TITLE
Prevent failures for some combinations of Moose and MooseX::ClassAttribute versions.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ author   'Evan Carroll <me+cpan@evancarroll.com>';
 license  'perl';
 
 requires 'Moose';
-requires 'MooseX::ClassAttribute' => '0.25';
+requires 'MooseX::ClassAttribute' => '0.27';
 requires 'namespace::autoclean';
 
 test_requires 'Test::More';

--- a/lib/Olson/Abbreviations.pm
+++ b/lib/Olson/Abbreviations.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Moose;
 
-use MooseX::ClassAttribute;
+use MooseX::ClassAttribute 0.27;
 use namespace::autoclean;
 
 our $VERSION = '0.04';


### PR DESCRIPTION
I examined all the cpantesters reports for stable Perl versions. Although pre-0.27 versions of MXCA work with Moose older than 2.0800, I wouldn't recommend messing with possible combinations. 0.27 is compatible with both old and new Moose (see 0.27 in [Changes](https://metacpan.org/changes/distribution/MooseX-ClassAttribute)).

As this fix is part of the Perl Pull Request Challenge, I'll blog about the details how I examined the reports later.